### PR TITLE
Disable unstable features

### DIFF
--- a/.emacs.d/.mew.d/.mew.el
+++ b/.emacs.d/.mew.d/.mew.el
@@ -1,7 +1,7 @@
 ;; Mew Setting
 
  ;; format-flowed
- (setq mew-use-format-flowed t)
+ (setq mew-use-format-flowed nil)
 
  ;; 未読マーク
  (setq mew-use-unread-mark t)
@@ -57,7 +57,7 @@
 (setq mew-mbox-command "incm")
 (setq mew-mbox-command-arg "-u -d $HOME/Maildir")
 
-(setq mew-use-biff t)
+(setq mew-use-biff nil)
 (setq mew-pop-biff-interval 1)
 (setq mew-use-cached-passwd t)
 (setq mew-passwd-lifetime 30)

--- a/.emacs.d/init.d/arch/gnu/linux/init.el
+++ b/.emacs.d/init.d/arch/gnu/linux/init.el
@@ -12,9 +12,9 @@
 ;; )
 ;;;
 ;;; see https://github.com/4U6U57/wsl-open
-(when (executable-find "wsl-open")
-  (setq browse-url-generic-program "wsl-open")
-  (setq browse-url-browser-function 'browse-url-generic))
+;; (when (executable-find "wsl-open")
+;;   (setq browse-url-generic-program "wsl-open")
+;;   (setq browse-url-browser-function 'browse-url-generic))
 
 (require 'server)
 (unless (server-running-p)

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -952,7 +952,7 @@
             #'(lambda ()
                 (setq web-mode-enable-auto-indentation nil)))
   (add-hook 'web-mode-hook 'editorconfig-apply)
-  (add-hook 'web-mode-hook 'prettier-js-mode)
+  ;; (add-hook 'web-mode-hook 'prettier-js-mode)
   (add-hook 'web-mode-hook
             #'(lambda ()
                 (when (string-equal "vue" (file-name-extension buffer-file-name))


### PR DESCRIPTION
This pull request includes several changes to Emacs configuration files, focusing on disabling certain features and modifying hooks. The most important changes involve disabling the `format-flowed` and `biff` settings in Mew, commenting out the use of `wsl-open`, and removing the `prettier-js-mode` hook in `web-mode`.

Changes to Mew settings:

* [`.emacs.d/.mew.d/.mew.el`](diffhunk://#diff-8db190e3236fe9e6c736377efbd22041697b673568a4445c9a42425eafc86089L4-R4): Disabled `format-flowed` by setting `mew-use-format-flowed` to `nil`.
* [`.emacs.d/.mew.d/.mew.el`](diffhunk://#diff-8db190e3236fe9e6c736377efbd22041697b673568a4445c9a42425eafc86089L60-R60): Disabled `biff` by setting `mew-use-biff` to `nil`.

Changes to browser and editor settings:

* [`.emacs.d/init.d/arch/gnu/linux/init.el`](diffhunk://#diff-72da4c81753011cbe0ffd6e1e25f8dd4a486f59558c2b05c008c53ad8793d1a3L15-R17): Commented out the configuration for `wsl-open` to disable its use.
* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507L955-R955): Commented out the `prettier-js-mode` hook in `web-mode`.