### PR TITLE
Enable copilot-mode in git-commit-mode

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -549,6 +549,9 @@
   :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "lisp")
            ("touch" "lisp/magit-autoloads.el"))
   :branch "main")
+(with-eval-after-load 'git-commit
+  ;; It is recommended to run `git config --global commit.verbose true`
+  (add-hook 'git-commit-setup-hook #'copilot-mode))
 (with-eval-after-load 'magit
   ;; (require 'forge)
   ;; see https://stackoverflow.com/a/32914548/4956633


### PR DESCRIPTION
This pull request includes a small change to the `.emacs.d/init.el` file. The change adds a hook to enable `copilot-mode` during the `git-commit-setup` process after loading the `git-commit` package.

* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507R552-R554): Added a hook to enable `copilot-mode` during the `git-commit-setup` process after loading the `git-commit` package.