### PR TITLE
feat: add shell-maker and copilot-chat.el packages

### DIFF
--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -1,5 +1,9 @@
 (setq el-get-lock-package-versions
-      '((puni :checksum "72e091ef30e0c9299dbcd0bc4669ab9bb8fb6e47")
+      '((shell-maker :checksum
+                     "72ce76bb3059e6c715b2471856851aac21198ac7")
+        (copilot-chat.el :checksum
+                         "a3a9f13506f6bb8105c625bbd731e6c0e741eec2")
+        (puni :checksum "72e091ef30e0c9299dbcd0bc4669ab9bb8fb6e47")
         (emacs-todoist :checksum
                        "205c730a4615dec20ea71ccd0a09479a420cb974")
         (modus-themes :checksum

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -536,6 +536,14 @@
   :type github
   :pkgname "emacsorphanage/tree-mode")
 (setenv "EDITOR" "emacsclient")
+(el-get-bundle shell-maker
+  :type github
+  :pkgname "xenodium/shell-maker"
+  :branch "main")
+(el-get-bundle chep/copilot-chat.el
+  :type github
+  :pkgname "chep/copilot-chat.el"
+  :depends (shell-maker))
 (el-get-bundle transient
   :branch "main")
 (el-get-bundle with-editor
@@ -551,7 +559,8 @@
   :branch "main")
 (with-eval-after-load 'git-commit
   ;; It is recommended to run `git config --global commit.verbose true`
-  (add-hook 'git-commit-setup-hook #'copilot-mode))
+  (add-hook 'git-commit-setup-hook #'copilot-mode)
+  (add-hook 'git-commit-setup-hook 'copilot-chat-insert-commit-message))
 (with-eval-after-load 'magit
   ;; (require 'forge)
   ;; see https://stackoverflow.com/a/32914548/4956633


### PR DESCRIPTION
This pull request includes updates to the `.emacs.d/init.el` file to add new packages and enhance the git commit setup. The most important changes are as follows:

### Package Additions:

* Added `shell-maker` package from GitHub repository `xenodium/shell-maker` on the `main` branch.
* Added `copilot-chat.el` package from GitHub repository `chep/copilot-chat.el` with a dependency on `shell-maker`.

### Git Commit Setup Enhancement:

* Added a hook to insert a commit message using `copilot-chat` during the git commit setup.