### PR TITLE
fix: update copilot package and set frontend to markdown

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -544,6 +544,8 @@
   :type github
   :pkgname "chep/copilot-chat.el"
   :depends (shell-maker))
+(setopt copilot-chat-frontend 'markdown)
+
 (el-get-bundle transient
   :branch "main")
 (el-get-bundle with-editor
@@ -881,7 +883,7 @@
 
 (el-get-bundle copilot
   :type github
-  :pkgname "zerolfx/copilot.el"
+  :pkgname "copilot-emacs/copilot.el"
   :branch "main")
 (add-hook 'prog-mode-hook 'copilot-mode)
 (defun copilot-tab ()


### PR DESCRIPTION
This pull request includes updates to the `.emacs.d/init.el` file to configure the Copilot and Copilot Chat packages. The most important changes include setting the frontend for Copilot Chat to Markdown and updating the package name for the Copilot package.

Configuration updates:

* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507R547-R548): Set the `copilot-chat-frontend` option to 'markdown'.
* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507L884-R886): Updated the `copilot` package name from `zerolfx/copilot.el` to `copilot-emacs/copilot.el`.