### PR TITLE
Modify setting to SKK and copilot

### DIFF
--- a/.emacs.d/init.d/skk-init.el
+++ b/.emacs.d/init.d/skk-init.el
@@ -21,7 +21,7 @@
 (setq skk-use-face t)
 (setq skk-use-color-cursor t)
 (setq skk-japanese-message-and-error nil)
-(setq skk-show-annotation t)
+(setq skk-show-annotation nil)
 (setq skk-auto-start-henkan t)
 (setq skk-show-icon t)
 (setq skk-dcomp-activate nil)

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -63,10 +63,10 @@
 (setq debug-on-error t)
 
 (setopt el-get-bundle-sync t
-      el-get-is-lazy t
-      el-get-verbose nil
-      el-get-bundle-byte-compile t
-      el-get-auto-update-cached-recipes nil)
+        el-get-is-lazy t
+        el-get-verbose nil
+        el-get-bundle-byte-compile t
+        el-get-auto-update-cached-recipes nil)
 
 (add-to-list 'load-path (locate-user-emacs-file "el-get/el-get"))
 (unless (require 'el-get nil 'noerror)
@@ -538,6 +538,24 @@
   :type github
   :pkgname "xenodium/shell-maker"
   :branch "main")
+
+(el-get-bundle copilot
+  :type github
+  :pkgname "copilot-emacs/copilot.el"
+  :branch "main")
+(add-hook 'prog-mode-hook 'copilot-mode)
+(defun copilot-tab ()
+  (interactive)
+  (or (copilot-accept-completion)
+      (indent-for-tab-command)))
+(with-eval-after-load 'copilot
+  (define-key copilot-mode-map (kbd "TAB") #'copilot-tab)
+  (define-key copilot-mode-map [(tab)] #'copilot-tab)
+  (define-key copilot-mode-map (kbd "C-TAB") #'copilot-accept-completion-by-word)
+  (define-key copilot-mode-map (kbd "C-<tab>") #'copilot-accept-completion-by-word)
+  (define-key copilot-mode-map (kbd "C-z n") #'copilot-next-completion)
+  (define-key copilot-mode-map (kbd "C-z p") #'copilot-previous-completion))
+
 (el-get-bundle chep/copilot-chat.el
   :type github
   :pkgname "chep/copilot-chat.el"
@@ -878,19 +896,6 @@
 ;;   :type github
 ;;   :pkgname "Alexander-Miller/treemacs"
 ;;   :load-path ("src/elisp"))
-
-(el-get-bundle copilot
-  :type github
-  :pkgname "copilot-emacs/copilot.el"
-  :branch "main")
-(add-hook 'prog-mode-hook 'copilot-mode)
-(defun copilot-tab ()
-  (interactive)
-  (or (copilot-accept-completion)
-      (indent-for-tab-command)))
-(with-eval-after-load 'copilot
-  (define-key copilot-mode-map (kbd "TAB") #'copilot-tab)
-  (define-key copilot-mode-map [(tab)] #'copilot-tab))
 
 (setq x-gtk-resize-child-frames 'resize-mode)
 (el-get-bundle lsp-bridge

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -61,6 +61,7 @@
 (defvar external-directory (expand-file-name "~/OneDrive - Skirnir Inc/emacs/"))
 (defvar openweathermap-api-key nil)
 (setq debug-on-error t)
+(setq warning-minimum-level :error)
 
 (setopt el-get-bundle-sync t
         el-get-is-lazy t

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -159,9 +159,7 @@
       skk-init-file (concat user-initial-directory "skk-init.el")
       skk-isearch-start-mode 'latin)
 (setq skk-preload nil)
-(add-hook 'skk-load-hook
-          (lambda ()
-            (require 'context-skk)))
+
 ;;; global key-bindings
 (add-hook
  'emacs-startup-hook


### PR DESCRIPTION
This pull request includes changes to the Emacs configuration files to modify settings, add new functionality, and remove redundant code. The most important changes include modifying SKK settings, updating error and warning handling, and integrating the Copilot package.

### SKK settings:
* [`.emacs.d/init.d/skk-init.el`](diffhunk://#diff-7d3b0373f4e55f702b66b430408827d88d88a9d8157f689b6756af5febd5012aL24-R24): Disabled the display of annotations by setting `skk-show-annotation` to `nil`.

### Error and warning handling:
* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507R64): Set the minimum warning level to `:error` to suppress less severe warnings.

### Package integration:
* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507R542-R559): Added configuration for the Copilot package, including loading the package, enabling `copilot-mode` in programming modes, and defining key bindings for Copilot commands.

### Code cleanup:
* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507L884-L896): Removed redundant Copilot configuration that was duplicated elsewhere in the file.
* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507L162-R163): Removed the hook to load `context-skk` when SKK is loaded.