### PR TITLE
ci: update CI configuration for Emacs version and dependencies

### DIFF
--- a/.emacs.d/bin/copilot-node-server
+++ b/.emacs.d/bin/copilot-node-server
@@ -1,1 +1,0 @@
-node_modules/.bin/copilot-node-server

--- a/.emacs.d/bin/eask
+++ b/.emacs.d/bin/eask
@@ -1,1 +1,0 @@
-node_modules/.bin/eask

--- a/.emacs.d/bin/package.json
+++ b/.emacs.d/bin/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {
-    "@emacs-eask/cli": "^0.10.0",
     "@mermaid-js/mermaid-cli": "^10.9.1",
     "bash-language-server": "^5.4.0",
     "dockerfile-language-server-nodejs": "^0.13.0",

--- a/.emacs.d/bin/package.json
+++ b/.emacs.d/bin/package.json
@@ -8,7 +8,6 @@
     "@emacs-eask/cli": "^0.10.0",
     "@mermaid-js/mermaid-cli": "^10.9.1",
     "bash-language-server": "^5.4.0",
-    "copilot-node-server": "^1.41.0",
     "dockerfile-language-server-nodejs": "^0.13.0",
     "typescript": "^5.5.4",
     "typescript-language-server": "^4.3.3",

--- a/.emacs.d/bin/yarn.lock
+++ b/.emacs.d/bin/yarn.lock
@@ -30,14 +30,6 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz#923ca57e173c6b232bbbb07347b1be982f03e783"
   integrity sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==
 
-"@emacs-eask/cli@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@emacs-eask/cli/-/cli-0.10.0.tgz#4e1dac6850fb8a5ea802d6320e0719fea0bb1966"
-  integrity sha512-c3Z2a6qzJxfADIKJ5BWnKjdkp3gfws2nqrMs9MPYBt0SFjqhKn0+0EJDfb/S5HlBpW9sZEy0FBq5hO6YFyicvQ==
-  dependencies:
-    which "^4.0.0"
-    yargs "^17.0.0"
-
 "@mermaid-js/mermaid-cli@^10.9.1":
   version "10.9.1"
   resolved "https://registry.yarnpkg.com/@mermaid-js/mermaid-cli/-/mermaid-cli-10.9.1.tgz#9ccd0a9fdb09275817617665ee5432d352c838cc"
@@ -1021,11 +1013,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-isexe@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/isexe/-/isexe-3.1.1.tgz#4a407e2bd78ddfb14bea0c27c6f7072dde775f0d"
-  integrity sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1955,13 +1942,6 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
-which@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/which/-/which-4.0.0.tgz#cd60b5e74503a3fbcfbf6cd6b4138a8bae644c1a"
-  integrity sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==
-  dependencies:
-    isexe "^3.1.1"
-
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -2018,19 +1998,6 @@ yargs@17.7.1:
   version "17.7.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
   integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
-
-yargs@^17.0.0:
-  version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/.emacs.d/bin/yarn.lock
+++ b/.emacs.d/bin/yarn.lock
@@ -349,11 +349,6 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-copilot-node-server@^1.41.0:
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/copilot-node-server/-/copilot-node-server-1.41.0.tgz#195b5e646b67176a118e5aaa393ba8663ad7e832"
-  integrity sha512-r2+uaWa05wvxNALv8rLegRCOlcopUDLYOd8kAHTAM8xpqBNK5TcMqFbGufxKF7YIWpBwcyfNaAIb724Un5e1eA==
-
 core-js@^3.20.1:
   version "3.38.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.38.0.tgz#8acb7c050bf2ccbb35f938c0d040132f6110f636"

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -192,7 +192,7 @@
         (smart-jump :checksum
                     "3392eb35e3cde37e6f5f2a48dc0db15ca535143c")
         (dumb-jump :checksum
-                   "9f3967b0bea038c37d4a6c6bb96144574bb706ee")
+                   "93665381d94a468e3fe965e3688995c1290e92b7")
         (popup :checksum "4b35c57ec88428233eecf27537854fc1f5f802ff")
         (multiple-cursors :checksum
                           "89f1a8df9b1fc721b1672b4c7b6d3ab451e7e3ef")

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -10,7 +10,7 @@
                       "243fc35181db62e4cadc10b29a8950072443eea0")
         (dired-preview :checksum
                        "411a6fd3608a42a5cb5a166ed9613366f426b664")
-        (ddskk :checksum "8c47f46e38a29a0f3eabcd524268d20573102467")
+        (ddskk :checksum "f81ed803e617ccd8175d4bf57a3062bc5ffe1945")
         (ebuild-mode :checksum
                      "529191d3b6691401f9612e761e1c5448f9359857")
         (eglot :checksum "db91d58374627a195b731a61bead9b4f84a7e4bc")

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -96,7 +96,7 @@
         (emacs-sql-indent :checksum
                           "2ed4c6a26b8f3d651ac6231eaafb2565d77c918b")
         (editorconfig :checksum
-                      "24f5b2b1cd4e37adc245fb59f7edeb6872a707a4")
+                      "1a9942746cf5b10daae8962f380b5f2a459086f3")
         (recentf-ext :checksum
                      "95f81dfac24d3f67002024f0a24e6b997bf6d647")
         (plantuml-mode :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -1,5 +1,8 @@
 (setq el-get-lock-package-versions
-      '((emacs-fsharp-mode :checksum
+      '((poly-markdown :checksum
+                       "98695eb7ca4ca11dcec71a1cab64903bbf79b4d3")
+        (polymode :checksum "74ba75d4bcfbea959ccc9080a95ab9ef759849f2")
+        (emacs-fsharp-mode :checksum
                            "677d78c4d6cb574086408082dedbcaef04a85359")
         (llama :checksum "9802c215a3eea748d9d7f81a1465850388006897")
         (ultra-scroll :checksum
@@ -7,7 +10,7 @@
         (shell-maker :checksum
                      "72ce76bb3059e6c715b2471856851aac21198ac7")
         (copilot-chat.el :checksum
-                         "efc6af7acc6c92165a71942ec30dafe73ac8ff1a")
+                         "d358e33f3f37267774c92f413f528cff89ecccb9")
         (puni :checksum "72e091ef30e0c9299dbcd0bc4669ab9bb8fb6e47")
         (emacs-todoist :checksum
                        "205c730a4615dec20ea71ccd0a09479a420cb974")
@@ -90,7 +93,7 @@
         (tree-mode :checksum
                    "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (with-editor :checksum
-          "ca902ae02972bdd6919a902be2593d8cb6bd991b")
+                     "ca902ae02972bdd6919a902be2593d8cb6bd991b")
         (terminal-here :checksum
                        "d321d9e33e42cba045341b0ef4d978056ad6f4d7")
         (emacs-sql-indent :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -18,7 +18,7 @@
         (eglot :checksum "db91d58374627a195b731a61bead9b4f84a7e4bc")
         (oauth2 :checksum "0147cabd8e82e46af27aef07aeed402b0bb9a0fb")
         (nerd-icons.el :checksum
-                       "66658b89287c3599c7b9b6babea7bcb3dff9a9e4")
+                       "546ee20caf825e65da4c5435d31f13d269ed2a81")
         (fsharp-mode :checksum
                      "677d78c4d6cb574086408082dedbcaef04a85359")
         (nard-icons.el :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -1,5 +1,7 @@
 (setq el-get-lock-package-versions
-      '((llama :checksum "9802c215a3eea748d9d7f81a1465850388006897")
+      '((emacs-fsharp-mode :checksum
+                           "677d78c4d6cb574086408082dedbcaef04a85359")
+        (llama :checksum "9802c215a3eea748d9d7f81a1465850388006897")
         (ultra-scroll :checksum
                       "2c517bf9b61bf432f706ff8a585ba453c7476be2")
         (shell-maker :checksum
@@ -88,7 +90,7 @@
         (tree-mode :checksum
                    "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (with-editor :checksum
-                     "ca902ae02972bdd6919a902be2593d8cb6bd991b")
+          "ca902ae02972bdd6919a902be2593d8cb6bd991b")
         (terminal-here :checksum
                        "d321d9e33e42cba045341b0ef4d978056ad6f4d7")
         (emacs-sql-indent :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -36,7 +36,7 @@
         (fosi :checksum "c1d5ed6bc4c6c1e5d8c14c21ff0d6234e65bc83a")
         (wakatime-mode :checksum
                        "25fb775178d16decb818b75f32fd23301c0f5da0")
-        (compat :checksum "8d4e8a366681def88751f5e9975738ecd3180deb")
+        (compat :checksum "bfc0a46098be2dcaad0518ec200ff5a2be5cc9bb")
         (lsp-bridge :checksum
                     "c4520d69effa9a01dc1ef2c025e713c7b6f3094f")
         (copilot :checksum "f831b2b8375950eb1cc282d15ccc78ed90f30a1a")
@@ -85,7 +85,7 @@
         (tree-mode :checksum
                    "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (with-editor :checksum
-                     "ca902ae02972bdd6919a902be2593d8cb6bd991b")
+          "ca902ae02972bdd6919a902be2593d8cb6bd991b")
         (terminal-here :checksum
                        "c996304c1e873e561108a509129b9e4358d354d5")
         (emacs-sql-indent :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -88,7 +88,7 @@
         (tree-mode :checksum
                    "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (with-editor :checksum
-                     "ca902ae02972bdd6919a902be2593d8cb6bd991b")
+          "ca902ae02972bdd6919a902be2593d8cb6bd991b")
         (terminal-here :checksum
                        "d321d9e33e42cba045341b0ef4d978056ad6f4d7")
         (emacs-sql-indent :checksum
@@ -183,7 +183,7 @@
         (helm-ls-git :checksum
                      "ae2202fbbbe11873ad4b393a6959da50ac250c1e")
         (helm :checksum "4e99cc8ef66aac2d824c456f58abe833be26c99d")
-        (howm :checksum "ffc1e7da1f02f750094a9f0fe8a0aa837743193b")
+        (howm :checksum "83e41a06994b92598eeefe78a23ba794b5474924")
         (magit :checksum "4a01405bf1b6cdcaafabcbf7692a1ad0f67ea7b5")
         (transient :checksum
                    "32a7e256aab281bada5db8569e0871c8c3ad2115")

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -4,13 +4,13 @@
         (polymode :checksum "74ba75d4bcfbea959ccc9080a95ab9ef759849f2")
         (emacs-fsharp-mode :checksum
                            "677d78c4d6cb574086408082dedbcaef04a85359")
-        (llama :checksum "9802c215a3eea748d9d7f81a1465850388006897")
+        (llama :checksum "27751668706838e845cee356b7299f734e1cc7dc")
         (ultra-scroll :checksum
                       "2c517bf9b61bf432f706ff8a585ba453c7476be2")
         (shell-maker :checksum
                      "72ce76bb3059e6c715b2471856851aac21198ac7")
         (copilot-chat.el :checksum
-                         "d358e33f3f37267774c92f413f528cff89ecccb9")
+                         "8a0049cb2eaab4f1aa62a074728f1ed5832a42c7")
         (puni :checksum "72e091ef30e0c9299dbcd0bc4669ab9bb8fb6e47")
         (emacs-todoist :checksum
                        "205c730a4615dec20ea71ccd0a09479a420cb974")
@@ -20,11 +20,11 @@
                        "411a6fd3608a42a5cb5a166ed9613366f426b664")
         (ddskk :checksum "f81ed803e617ccd8175d4bf57a3062bc5ffe1945")
         (ebuild-mode :checksum
-                     "320b265f51ecef41a757f284fac6ace58036f541")
+                     "1dd08c89bc71ca802daaa05cfdc7f028b7254159")
         (eglot :checksum "db91d58374627a195b731a61bead9b4f84a7e4bc")
         (oauth2 :checksum "0147cabd8e82e46af27aef07aeed402b0bb9a0fb")
         (nerd-icons.el :checksum
-                       "3a47753ef4f9d7e83474f50c0188a7b39f1ff32d")
+                       "a29fcbc24a7827d5e97a05302398f15a155fe18a")
         (fsharp-mode :checksum
                      "677d78c4d6cb574086408082dedbcaef04a85359")
         (nard-icons.el :checksum
@@ -46,7 +46,7 @@
                        "1c5b2254dd72f2ff504d6a6189a8c10be03a98d1")
         (compat :checksum "bfc0a46098be2dcaad0518ec200ff5a2be5cc9bb")
         (lsp-bridge :checksum
-                    "4401d1396dce89d1fc5dc5414565818dd1c30ae0")
+                    "cecb939f40ebde5c82d888a532c0494969997b4a")
         (copilot :checksum "8a0068afcfb98af7f172d04f6f8cc932c1a22fe8")
         (eldoc-box :checksum
                    "5c067f5c195198ffd16df2f455da95e46cc8ce02")
@@ -75,8 +75,8 @@
                    "c7cb04499d94ee1c17affb29b1cfcd2a45116c97")
         (marginalia :checksum
                     "a527fb03b76a2bce1e360c6e73a095e06922c3f3")
-        (consult :checksum "2643235a853d55805822239bb2cd75a7aabef48d")
-        (vertico :checksum "e69ef62ffa4bc42dd42437881c251ecdcae0e0c5")
+        (consult :checksum "ce38dd037769ccba93e7b854ab9b0cc0eced84ee")
+        (vertico :checksum "ac82acf177a0dfc97deac8626a8a98c06bffc96c")
         (gcmh :checksum "0089f9c3a6d4e9a310d0791cf6fa8f35642ecfd9")
         (with-eval-after-load-feature-el :checksum
                                          "0b38651a5f0dafdfe04bd0032eb5ff803e99460b")
@@ -169,15 +169,15 @@
         (avy :checksum "955c8dedd68c74f3cf692c1249513f048518c4c9")
         (hydra :checksum "317e1de33086637579a7aeb60f77ed0405bf359b")
         (pfuture :checksum "19b53aebbc0f2da31de6326c495038901bffb73c")
-        (flycheck :checksum "af1e8ca7257298dd6c51ed4424c09283b4fedb7a")
+        (flycheck :checksum "86715c0f293738623f632d6f54a7d1be78b1c48f")
         (pkg-info :checksum "76ba7415480687d05a4353b27fea2ae02b8d9d61")
         (epl :checksum "78ab7a85c08222cd15582a298a364774e3282ce6")
         (ht :checksum "1c49aad1c820c86f7ee35bf9fff8429502f60fef")
         (spinner :checksum "d4647ae87fb0cd24bc9081a3d287c860ff061c21")
-        (request :checksum "01e338c335c07e4407239619e57361944a82cb8a")
+        (request :checksum "c22e3c23a6dd90f64be536e176ea0ed6113a5ba6")
         (deferred :checksum "2239671d94b38d92e9b28d4e12fd79814cfb9c16")
         (markdown-mode :checksum
-                       "038f0fb9789afafff99b7f23de107862dde113ee")
+                       "ee9d6de1d246936c1b63bbc4515986b489c7add6")
         (frame-local :checksum
                      "7ee1106c3bcd4022f48421f8cb1ef4f995da816e")
         (helm-swoop :checksum
@@ -188,8 +188,8 @@
         (helm-ls-git :checksum
                      "ae2202fbbbe11873ad4b393a6959da50ac250c1e")
         (helm :checksum "4e99cc8ef66aac2d824c456f58abe833be26c99d")
-        (howm :checksum "83e41a06994b92598eeefe78a23ba794b5474924")
-        (magit :checksum "4a01405bf1b6cdcaafabcbf7692a1ad0f67ea7b5")
+        (howm :checksum "00fb080ccc7d6929a6ee9bb480484c9308727d09")
+        (magit :checksum "9914feb4d5a2feab091076be554d80781594869d")
         (transient :checksum
                    "0439eb80d89e51b71e71faac689b1136f180ec46")
         (smart-jump :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -191,7 +191,7 @@
         (howm :checksum "00fb080ccc7d6929a6ee9bb480484c9308727d09")
         (magit :checksum "9914feb4d5a2feab091076be554d80781594869d")
         (transient :checksum
-                   "0439eb80d89e51b71e71faac689b1136f180ec46")
+                   "abb71675b5b538c91c838207385b913b58e29718")
         (smart-jump :checksum
                     "3392eb35e3cde37e6f5f2a48dc0db15ca535143c")
         (dumb-jump :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -185,7 +185,7 @@
         (howm :checksum "ffc1e7da1f02f750094a9f0fe8a0aa837743193b")
         (magit :checksum "873da4a62dc609ff0c8a7e0ec417b263e3ed2269")
         (transient :checksum
-                   "fe71a7e7d63c1685d22b59e792c6b67cefebf2af")
+                   "32a7e256aab281bada5db8569e0871c8c3ad2115")
         (smart-jump :checksum
                     "3392eb35e3cde37e6f5f2a48dc0db15ca535143c")
         (dumb-jump :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -70,7 +70,7 @@
                    "c7cb04499d94ee1c17affb29b1cfcd2a45116c97")
         (marginalia :checksum
                     "a527fb03b76a2bce1e360c6e73a095e06922c3f3")
-        (consult :checksum "dea4eaf621b6477cca514bfa32c950004fb9cc99")
+        (consult :checksum "2643235a853d55805822239bb2cd75a7aabef48d")
         (vertico :checksum "e69ef62ffa4bc42dd42437881c251ecdcae0e0c5")
         (gcmh :checksum "0089f9c3a6d4e9a310d0791cf6fa8f35642ecfd9")
         (with-eval-after-load-feature-el :checksum
@@ -88,7 +88,7 @@
         (tree-mode :checksum
                    "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (with-editor :checksum
-          "ca902ae02972bdd6919a902be2593d8cb6bd991b")
+                     "ca902ae02972bdd6919a902be2593d8cb6bd991b")
         (terminal-here :checksum
                        "d321d9e33e42cba045341b0ef4d978056ad6f4d7")
         (emacs-sql-indent :checksum
@@ -186,7 +186,7 @@
         (howm :checksum "83e41a06994b92598eeefe78a23ba794b5474924")
         (magit :checksum "4a01405bf1b6cdcaafabcbf7692a1ad0f67ea7b5")
         (transient :checksum
-                   "32a7e256aab281bada5db8569e0871c8c3ad2115")
+                   "0439eb80d89e51b71e71faac689b1136f180ec46")
         (smart-jump :checksum
                     "3392eb35e3cde37e6f5f2a48dc0db15ca535143c")
         (dumb-jump :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -21,7 +21,7 @@
         (eglot :checksum "db91d58374627a195b731a61bead9b4f84a7e4bc")
         (oauth2 :checksum "0147cabd8e82e46af27aef07aeed402b0bb9a0fb")
         (nerd-icons.el :checksum
-                       "546ee20caf825e65da4c5435d31f13d269ed2a81")
+                       "3a47753ef4f9d7e83474f50c0188a7b39f1ff32d")
         (fsharp-mode :checksum
                      "677d78c4d6cb574086408082dedbcaef04a85359")
         (nard-icons.el :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((ultra-scroll :checksum
+      '((llama :checksum "9802c215a3eea748d9d7f81a1465850388006897")
+        (ultra-scroll :checksum
                       "2c517bf9b61bf432f706ff8a585ba453c7476be2")
         (shell-maker :checksum
                      "72ce76bb3059e6c715b2471856851aac21198ac7")
@@ -183,7 +184,7 @@
                      "ae2202fbbbe11873ad4b393a6959da50ac250c1e")
         (helm :checksum "4e99cc8ef66aac2d824c456f58abe833be26c99d")
         (howm :checksum "ffc1e7da1f02f750094a9f0fe8a0aa837743193b")
-        (magit :checksum "873da4a62dc609ff0c8a7e0ec417b263e3ed2269")
+        (magit :checksum "4a01405bf1b6cdcaafabcbf7692a1ad0f67ea7b5")
         (transient :checksum
                    "32a7e256aab281bada5db8569e0871c8c3ad2115")
         (smart-jump :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -44,7 +44,7 @@
         (compat :checksum "bfc0a46098be2dcaad0518ec200ff5a2be5cc9bb")
         (lsp-bridge :checksum
                     "4401d1396dce89d1fc5dc5414565818dd1c30ae0")
-        (copilot :checksum "867a3debf907cbd7c5b0eb8837354a1efc7c2db9")
+        (copilot :checksum "8a0068afcfb98af7f172d04f6f8cc932c1a22fe8")
         (eldoc-box :checksum
                    "5c067f5c195198ffd16df2f455da95e46cc8ce02")
         (consult-tramp :checksum

--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -1,8 +1,10 @@
 (setq el-get-lock-package-versions
-      '((shell-maker :checksum
+      '((ultra-scroll :checksum
+                      "2c517bf9b61bf432f706ff8a585ba453c7476be2")
+        (shell-maker :checksum
                      "72ce76bb3059e6c715b2471856851aac21198ac7")
         (copilot-chat.el :checksum
-                         "a3a9f13506f6bb8105c625bbd731e6c0e741eec2")
+                         "efc6af7acc6c92165a71942ec30dafe73ac8ff1a")
         (puni :checksum "72e091ef30e0c9299dbcd0bc4669ab9bb8fb6e47")
         (emacs-todoist :checksum
                        "205c730a4615dec20ea71ccd0a09479a420cb974")
@@ -12,34 +14,34 @@
                        "411a6fd3608a42a5cb5a166ed9613366f426b664")
         (ddskk :checksum "f81ed803e617ccd8175d4bf57a3062bc5ffe1945")
         (ebuild-mode :checksum
-                     "529191d3b6691401f9612e761e1c5448f9359857")
+                     "320b265f51ecef41a757f284fac6ace58036f541")
         (eglot :checksum "db91d58374627a195b731a61bead9b4f84a7e4bc")
-        (oauth2 :checksum "cc2dd7f3e2aae621365a8297b61198c1694bdb5e")
+        (oauth2 :checksum "0147cabd8e82e46af27aef07aeed402b0bb9a0fb")
         (nerd-icons.el :checksum
                        "66658b89287c3599c7b9b6babea7bcb3dff9a9e4")
         (fsharp-mode :checksum
-                     "b4d31c3da018cfbb3d1f9e6fd416d8777f0835bd")
+                     "677d78c4d6cb574086408082dedbcaef04a85359")
         (nard-icons.el :checksum
                        "8095215a503d8048739de8b4ea4066598edb8cbb")
         (undo-tree :checksum
-                   "7eb78fa1fcb076621235c46fc730f485d3225dbb")
+                   "f55637665de4dc1f3d8cae28f456a84b3a5655f8")
         (tree-sitter-php-mode :checksum
                               "2f791d9d83c35b11e9a14daf9a58dd7e23566041")
         (php-ts-mode :checksum
                      "6c0214eb1a323cfc9cedb5e187c4ed20da763e9b")
-        (jq-mode :checksum "d533567a680bc87060c56a50f83d80e58646d2f2")
+        (jq-mode :checksum "eeb86b4d5ad823e97bd19979fcb22d0aa90ff07b")
         (terraform-mode :checksum
-                        "abfc10f5e313c4bb99de136a14636e9bc6df74f6")
+                        "5bdd734a87f67f6574664f63eb4d02a0bc74c0d0")
         (hcl-mode :checksum "ec27736c4c16fbf7f1ecab0210ec3c71ac2406fa")
         (elisp-tree-sitter :checksum
                            "fa5a072128da1235e237da827daf53f71a2cd562")
         (fosi :checksum "c1d5ed6bc4c6c1e5d8c14c21ff0d6234e65bc83a")
         (wakatime-mode :checksum
-                       "25fb775178d16decb818b75f32fd23301c0f5da0")
+                       "1c5b2254dd72f2ff504d6a6189a8c10be03a98d1")
         (compat :checksum "bfc0a46098be2dcaad0518ec200ff5a2be5cc9bb")
         (lsp-bridge :checksum
-                    "c4520d69effa9a01dc1ef2c025e713c7b6f3094f")
-        (copilot :checksum "f831b2b8375950eb1cc282d15ccc78ed90f30a1a")
+                    "4401d1396dce89d1fc5dc5414565818dd1c30ae0")
+        (copilot :checksum "867a3debf907cbd7c5b0eb8837354a1efc7c2db9")
         (eldoc-box :checksum
                    "5c067f5c195198ffd16df2f455da95e46cc8ce02")
         (consult-tramp :checksum
@@ -55,20 +57,20 @@
                    "2df1fbc965c5ef82906a0fa76b3517c5831d3581")
         (esup :checksum "4b49c8d599d4cc0fbf994e9e54a9c78e5ab62a5f")
         (consult-dir :checksum
-                     "3f5f4b71ebe819392cb090cda71bd39a93bd830a")
+                     "6cb46395df8f02ec5e5f4b58a08281e6981fda15")
         (consult-flycheck :checksum
-                          "754f5497d827f7d58009256a21af614cc44378a3")
+                          "3bc2141daf8cfad7e4d2e2f78b15d45033f707a5")
         (sudo-edit :checksum
                    "74eb1e6986461baed9a9269566ff838530b4379b")
         (consult-ls-git :checksum
-                        "3ccd9d80da73a05ef2a74616ffdc469860f74c21")
-        (embark :checksum "15c95aee0ec6f42ee3b7a0bc6cf1e2c1ad91dfcd")
+                        "beb253374e2cee10b8682fb8b377ca1f2caa4e27")
+        (embark :checksum "d5df0eff182b014ab49328a4dbb1d69eb7faafbd")
         (orderless :checksum
-                   "3847f311077efa17951a786d2759f2639c5f43c8")
+                   "c7cb04499d94ee1c17affb29b1cfcd2a45116c97")
         (marginalia :checksum
-                    "3275d1f85cb020280979a050054b843f7563aea2")
-        (consult :checksum "7533460e530a1e7abc89b4da8ad99b696fca8a30")
-        (vertico :checksum "68e51fda552a2f91caab69e83564bc91275b09b1")
+                    "a527fb03b76a2bce1e360c6e73a095e06922c3f3")
+        (consult :checksum "dea4eaf621b6477cca514bfa32c950004fb9cc99")
+        (vertico :checksum "e69ef62ffa4bc42dd42437881c251ecdcae0e0c5")
         (gcmh :checksum "0089f9c3a6d4e9a310d0791cf6fa8f35642ecfd9")
         (with-eval-after-load-feature-el :checksum
                                          "0b38651a5f0dafdfe04bd0032eb5ff803e99460b")
@@ -81,24 +83,24 @@
         (emacsql :checksum "373975cbccf7776af771e23f86043b236a330702")
         (yaml :checksum "73fde9d8fbbaf2596449285df9eb412ae9dd74d9")
         (mermaid-mode :checksum
-                      "d8bfb8c819cda9ead19c871842f6b0b8d56c56c0")
+                      "e74d4da7612c7a88e07f9dd3369e3b9fd36f396c")
         (tree-mode :checksum
                    "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (with-editor :checksum
-          "ca902ae02972bdd6919a902be2593d8cb6bd991b")
+                     "ca902ae02972bdd6919a902be2593d8cb6bd991b")
         (terminal-here :checksum
-                       "c996304c1e873e561108a509129b9e4358d354d5")
+                       "d321d9e33e42cba045341b0ef4d978056ad6f4d7")
         (emacs-sql-indent :checksum
-                          "c3dd49ccd1f0655ed1699058c16a777ac1cb1419")
+                          "2ed4c6a26b8f3d651ac6231eaafb2565d77c918b")
         (editorconfig :checksum
-                      "6b85f0475f01ff97f3233acb68e2646d2ca32a91")
+                      "24f5b2b1cd4e37adc245fb59f7edeb6872a707a4")
         (recentf-ext :checksum
                      "95f81dfac24d3f67002024f0a24e6b997bf6d647")
         (plantuml-mode :checksum
                        "5889166b6cfe94a37532ea27fc8de13be2ebfd02")
         (po-mode :checksum "3c97f0d391751956fdcf9f4c858d45c60405dd35")
         (nginx-mode :checksum
-                    "6e9d96f58eddd69f62f7fd443d9b9753e16e0e96")
+                    "c4ac5de975d65c84893a130a470af32a48b0b66c")
         (emacs-id-manager :checksum
                           "bbccd544fd1ced59a605b3814480cef7cc3b9afa")
         (sqlite-dump :checksum
@@ -109,31 +111,31 @@
                      "cbe842fd78e4b742ece9fc493ebf43e69d872866")
         (auto-save-buffers-enhanced :checksum
                                     "461e8c816c1b7c650be5f209078b381fe55da8c6")
-        (popwin :checksum "f4bf2e4cbda328359b06d89e233c951cba30363e")
+        (popwin :checksum "0d5788074a9df6a7a0285be58cfc3a5a545bb5c4")
         (twittering-mode :checksum
                          "114891e8fdb4f06b1326a6cf795e49c205cf9e29")
         (mew :checksum "c46d8ee784d098244abaf162660073d1d4787b60")
         (dockerfile-mode :checksum
-                         "39a012a27fcf6fb629c447d13b6974baf906714c")
+                         "4d893bd2da15833ce056332e6c972d5d93e78f04")
         (lsp-haskell :checksum
                      "485c1148ce4d27030bb95b21c7289809294e7d31")
         (haskell-mode :checksum
-                      "d23ec34788286405f377ce485d2a17e302d94a4f")
+                      "7f452cc9e6c3316b5a4a2b790d3a396f271609d9")
         (csharp-mode :checksum
                      "02c61c219b2c22491eff9b7315fed661fab423d4")
-        (csv-mode :checksum "63f02980978f19786bda354457ac5259b8f969a2")
+        (csv-mode :checksum "849ce3e754f291c3643bc36ed802226606955c3f")
         (groovy-mode :checksum
                      "7b8520b2e2d3ab1d62b35c426e17ac25ed0120bb")
-        (phpstan :checksum "563589435a798250274306dbb9cd4c85e9949d6c")
+        (phpstan :checksum "05de1e4ab10aa59b21b62c61c00dd5fa14c89f55")
         (phpactor :checksum "272217fbb6b7e7f70615fc518d77c6d75f33a44f")
-        (composer :checksum "91945f1bdb655be272320d14dab306b661a128a1")
+        (composer :checksum "6c7e19256ff964546cea682edd21446c465a663c")
         (php-skeleton :checksum
-                      "0e0f891e7dd8335bddc1335eca7f424394e524ce")
+                      "10b18be29c46fd3bc9d95300dabece1536388cb1")
         (php-runtime :checksum
-                     "b01e840ecf23690595ea109e04889fafdb526619")
+                     "37beef404c70d7b80dc085b1ee1e13fd9c375fe6")
         (php-mode :checksum "4a29636243ba7f4afba476348587713531d994bc")
         (yaml-mode :checksum
-                   "7b5ce294fb15c2c8926fa476d7218aa415550a2a")
+                   "d91f878729312a6beed77e6637c60497c5786efa")
         (web-mode :checksum "b9c351e75ae9fc19a026b4386f15c46264bc4520")
         (web-completion-data :checksum
                              "c272c94e8a71b779c29653a532f619acad433a4f")
@@ -153,7 +155,7 @@
         (lsp-treemacs :checksum
                       "9859326df6b8e8c954a3c227e53b6878e54aaae8")
         (lsp-mode :checksum "7153b3d8648e8bad780df2dc2801170f943c5c9d")
-        (posframe :checksum "017deece88360c7297265680d78a0bb316470716")
+        (posframe :checksum "12f540c9ad5da09673b2bca1132b41f94c134e82")
         (bui :checksum "f3a137628e112a91910fd33c0cff0948fa58d470")
         (treemacs :checksum "8b7638e69f64dcef05f1bd04dbc82c829e8bf261")
         (ace-window :checksum
@@ -161,7 +163,7 @@
         (avy :checksum "955c8dedd68c74f3cf692c1249513f048518c4c9")
         (hydra :checksum "317e1de33086637579a7aeb60f77ed0405bf359b")
         (pfuture :checksum "19b53aebbc0f2da31de6326c495038901bffb73c")
-        (flycheck :checksum "bf11b2a3eb2f9dc0eb07cc8fb6b5be606e6a698a")
+        (flycheck :checksum "af1e8ca7257298dd6c51ed4424c09283b4fedb7a")
         (pkg-info :checksum "76ba7415480687d05a4353b27fea2ae02b8d9d61")
         (epl :checksum "78ab7a85c08222cd15582a298a364774e3282ce6")
         (ht :checksum "1c49aad1c820c86f7ee35bf9fff8429502f60fef")
@@ -169,12 +171,12 @@
         (request :checksum "01e338c335c07e4407239619e57361944a82cb8a")
         (deferred :checksum "2239671d94b38d92e9b28d4e12fd79814cfb9c16")
         (markdown-mode :checksum
-                       "6102ac5b7301b4c4fc0262d9c6516693d5a33f2b")
+                       "038f0fb9789afafff99b7f23de107862dde113ee")
         (frame-local :checksum
                      "7ee1106c3bcd4022f48421f8cb1ef4f995da816e")
         (helm-swoop :checksum
                     "1b3285791f1dc1fde548fe67aec07214d698fd57")
-        (wgrep :checksum "208b9d01cfffa71037527e3a324684b3ce45ddc4")
+        (wgrep :checksum "49f09ab9b706d2312cab1199e1eeb1bcd3f27f6f")
         (helm-descbinds :checksum
                         "b72515982396b6e336ad7beb6767e95a80fca192")
         (helm-ls-git :checksum
@@ -187,16 +189,16 @@
         (smart-jump :checksum
                     "3392eb35e3cde37e6f5f2a48dc0db15ca535143c")
         (dumb-jump :checksum
-                   "ede6a04187e79a29ef31d14760ac0d8d4c5f4cc5")
-        (popup :checksum "4d6f6c22a5abf130fe8359171cb9d6b00dc41c0b")
+                   "9f3967b0bea038c37d4a6c6bb96144574bb706ee")
+        (popup :checksum "4b35c57ec88428233eecf27537854fc1f5f802ff")
         (multiple-cursors :checksum
-                          "c870c18462461df19382ecd2f9374c8b902cd804")
+                          "89f1a8df9b1fc721b1672b4c7b6d3ab451e7e3ef")
         (expand-region :checksum
-                       "e8f4e0fe9c9a80a6a26e2b438502aba9a799d580")
+                       "351279272330cae6cecea941b0033a8dd8bcc4e8")
         (yasnippet-snippets :checksum
-                            "e6ec9f1822913cea7dc67cde6aeb8f2625980950")
+                            "f1907ed38acc479e78d5c113810465e4d77d8604")
         (yasnippet :checksum
-                   "33587a8551b8f6991b607d3532062a384c010ce1")
+                   "5b315f1753480ebe669b157b8242448b5eafcfea")
         (easy-kill :checksum
                    "de7d66c3c864a4722a973ee9bc228a14be49ba0c")
         (visual-regexp :checksum
@@ -207,21 +209,21 @@
         (emacs-async :checksum
                      "3bd17d58e1ca14c629e72acfbd77138ff5adc1d6")
         (symbol-overlay :checksum
-                        "de215fff392c916ffab01950fcb6daf6fd18be4f")
+                        "6151f4279bd94b5960149596b202cdcb45cacec2")
         (doom-modeline :checksum
-                       "9920ef511620e9fa5599cb357e48487f758b1bb1")
+                       "9d6f0f9635ae722b6bd943a76e996f54443e373f")
         (eldoc-eval :checksum
                     "e91800503c90cb75dc70abe42f1d6ae499346cc1")
         (shrink-path :checksum
                      "0bf09bf4d4a90ca183a8806271740239d3ae6703")
-        (f :checksum "1e7020dc0d4c52d3da9bd610d431cab13aa02d8c")
+        (f :checksum "931b6d0667fe03e7bf1c6c282d6d8d7006143c52")
         (s :checksum "dda84d38fffdaf0c9b12837b504b402af910d01d")
-        (dash :checksum "5df7605da5a080df769d4f260034fb0e5e86a7a4")
+        (dash :checksum "1de9dcb83eacfb162b6d9a118a4770b1281bcd84")
         (cp5022x :checksum "ea7327dd75e54539576916f592ae1be98179ae35")
         (doom-themes :checksum
-                     "b6872fa0963cd4ae2e87938563429e82599bb6d4")
+                     "e506a8724156da3b1e62cb8136265e9705549d04")
         (all-the-icons :checksum
-                       "ee414384938ccf2ce93c77d717b85dc5538a257d")
+                       "39ef44f810c34e8900978788467cc675870bcd19")
         (memoize :checksum "51b075935ca7070f62fae1d69fe0ff7d8fa56fdd")
         (el-get-lock :checksum
                      "df8cfe55441695865a64b97946750b6413a40425")))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -564,6 +564,9 @@
   :depends (shell-maker))
 (setopt copilot-chat-frontend 'markdown)
 
+(el-get-bundle llama
+  :type github
+  :pkgname "tarsius/llama")
 (el-get-bundle transient
   :branch "main")
 (el-get-bundle with-editor

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1049,8 +1049,7 @@
 (el-get-bundle fsharp-mode
   :type github
   :pkgname "fsharp/emacs-fsharp-mode"
-  :depends (jsonrpc)
-  :load-path ("."))
+  :depends (jsonrpc))
 
 (el-get-bundle haskell-mode
   :type github

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -646,9 +646,9 @@
 
 (setopt howm-directory (concat external-directory "howm/"))
 (el-get-bundle howm
-  :type github
-  :pkgname "kaorahi/howm"
-  :build `(("./configure" ,(concat "--with-emacs=" el-get-emacs)) ("make"))
+  ;; :type github
+  ;; :pkgname "kaorahi/howm"
+  ;; :build `(("./configure" ,(concat "--with-emacs=" el-get-emacs)) ("make"))
   :prepare (progn
              (defvar howm-menu-lang 'ja)
              (defvar howm-file-name-format "%Y/%m/%Y-%m-%d-%H%M%S.txt")

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -557,11 +557,16 @@
   (define-key copilot-mode-map (kbd "C-<tab>") #'copilot-accept-completion-by-word)
   (define-key copilot-mode-map (kbd "C-z n") #'copilot-next-completion)
   (define-key copilot-mode-map (kbd "C-z p") #'copilot-previous-completion))
-
-(el-get-bundle chep/copilot-chat.el
+(el-get-bundle polymode
+  :type github
+  :pkgname "polymode/polymode")
+(el-get-bundle poly-markdown
+  :type github
+  :pkgname "polymode/poly-markdown")
+(el-get-bundle copilot-chat.el
   :type github
   :pkgname "chep/copilot-chat.el"
-  :depends (shell-maker))
+  :depends (polymode poly-markdown))
 (setopt copilot-chat-frontend 'markdown)
 
 (el-get-bundle llama

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -566,7 +566,8 @@
 
 (el-get-bundle llama
   :type github
-  :pkgname "tarsius/llama")
+  :pkgname "tarsius/llama"
+  :branch "main")
 (el-get-bundle transient
   :branch "main")
 (el-get-bundle with-editor

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -1114,18 +1114,6 @@
 (modify-coding-system-alist 'file "\\.po\\'\\|\\.po\\."
                             'po-find-file-coding-system)
 
-
-;;; brew install plantuml
-(el-get-bundle plantuml-mode
-  :type github
-  :pkgname "skuro/plantuml-mode")
-(add-to-list 'auto-mode-alist '("\\.puml$" . plantuml-mode))
-(with-eval-after-load 'plantuml-mode
-  (setq plantuml-indent-level 2)
-  (setq plantuml-executable-path "plantuml")
-  (setq plantuml-default-exec-mode 'executable)
-  (setq plantuml-output-type "png"))
-
 (el-get-bundle mermaid-mode
   :type github
   :pkgname "abrochard/mermaid-mode")

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -320,7 +320,8 @@
 (el-get-bundle all-the-icons)
 (el-get-bundle nerd-icons.el
   :type github
-  :pkgname "rainstormstudio/nerd-icons.el")
+  :pkgname "rainstormstudio/nerd-icons.el"
+  :branch "main")
 (with-eval-after-load 'nerd-icons
   (setf (alist-get "php" nerd-icons-extension-icon-alist)
         '(nerd-icons-sucicon "nf-seti-php" :face nerd-icons-lpurple))

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -646,9 +646,9 @@
 
 (setopt howm-directory (concat external-directory "howm/"))
 (el-get-bundle howm
-  ;; :type github
-  ;; :pkgname "kaorahi/howm"
-  ;; :build `(("./configure" ,(concat "--with-emacs=" el-get-emacs)) ("make"))
+  :type github
+  :pkgname "kaorahi/howm"
+  :build `(("./configure" ,(concat "--with-emacs=" el-get-emacs)) ("make"))
   :prepare (progn
              (defvar howm-menu-lang 'ja)
              (defvar howm-file-name-format "%Y/%m/%Y-%m-%d-%H%M%S.txt")
@@ -1046,7 +1046,7 @@
   :pkgname "Groovy-Emacs-Modes/groovy-emacs-modes")
 
 (el-get-bundle csv-mode in emacsmirror/csv-mode)
-(el-get-bundle fsharp-mode
+(el-get-bundle emacs-fsharp-mode
   :type github
   :pkgname "fsharp/emacs-fsharp-mode"
   :depends (jsonrpc))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-latest]
+        os:
+          - ubuntu-24.04
+          # - macos-latest
         emacs-version:
           - "release-snapshot"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,3 @@ jobs:
     - run: yarn install --frozen-lockfile
       working-directory: .emacs.d/bin
     - run: emacs -Q -l .emacs.d/early-init.el -l .emacs.d/init.el  --batch
-    - name: Eask
-      run: |
-        eask clean all
-        eask compile
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04, macos-latest]
         emacs-version:
-          - "29.4"
+          - "release-snapshot"
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -38,8 +38,6 @@ jobs:
       working-directory: .emacs.d/bin
     - run: yarn install --frozen-lockfile
       working-directory: .emacs.d/bin
-    - run: pip3 install -r bin/requirements.txt
-      working-directory: .emacs.d
     - run: emacs -Q -l .emacs.d/early-init.el -l .emacs.d/init.el  --batch
     - name: Eask
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,15 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
+    - name: Setup PHP with composer v2
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+        tools: composer:v2
+    - name: Install Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: 22
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.12'
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs-version }}


### PR DESCRIPTION
This pull request includes several changes to the Emacs configuration and CI workflow files. The most important changes include updating package configurations, adding new packages, and modifying the CI workflow to support additional languages and tools.

### Package Configuration Updates:

* Updated `nerd-icons.el` to use the `main` branch in `.emacs.d/init.el`.
* Renamed `fsharp-mode` to `emacs-fsharp-mode` and adjusted its dependencies in `.emacs.d/init.el`.
* Removed `plantuml-mode` configuration from `.emacs.d/init.el`.

### New Package Additions:

* Added `polymode`, `poly-markdown`, and `llama` packages in `.emacs.d/init.el`.

### CI Workflow Modifications:

* Commented out `macos-latest` and changed `emacs-version` to `release-snapshot` in `.github/workflows/ci.yml`.
* Added setup steps for Ruby, PHP with Composer v2, and Node.js in `.github/workflows/ci.yml`.
* Removed the `pip3 install` step and `Eask` commands in `.github/workflows/ci.yml`.