### PR TITLE
fix: enable editorconfig mode in init.el

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -366,8 +366,7 @@
 
 ;;; Indent settings
 (setq-default indent-tabs-mode nil)
-
-(el-get-bundle editorconfig)
+(editorconfig-mode 1)
 (el-get-bundle prettier-js)
 
 ;;; Misc settings


### PR DESCRIPTION
This pull request includes a small change to the `.emacs.d/init.el` file. The change replaces the `el-get-bundle` call for `editorconfig` with enabling `editorconfig-mode` directly.

* [`.emacs.d/init.el`](diffhunk://#diff-d8951da430c285ff25113e010d9227b1b9a16bf9067f040072145bbe46a8c507L369-R369): Replaced `(el-get-bundle editorconfig)` with `(editorconfig-mode 1)` to enable `editorconfig-mode` directly.