### PR TITLE
1Password Integration

### DIFF
--- a/.zsh/.zaliases
+++ b/.zsh/.zaliases
@@ -80,3 +80,7 @@ find_file() {
 say() {
     vterm_cmd message "%s" "$*"
 }
+
+# 1Password integration
+alias ssh='/mnt/c/Windows/System32/OpenSSH/ssh.exe'
+alias ssh-add='/mnt/c/Windows/System32/OpenSSH/ssh-add.exe'

--- a/.zsh/.zshrc
+++ b/.zsh/.zshrc
@@ -74,6 +74,22 @@ fi
 
 eval "$(fzf --zsh)"
 
+# see https://qiita.com/mfunaki/items/db6e1ffcf1e6f1eff252#wsl2%E5%81%B4%E3%81%A7%E3%81%AE%E8%A8%AD%E5%AE%9A%E5%8B%95%E4%BD%9C%E7%A2%BA%E8%AA%8D
+# need `ps -ww` to get non-truncated command for matching
+# use square brackets to generate a regex match for the process we want but that doesn't match the grep command running it!
+ALREADY_RUNNING=$(ps -auxww | grep -q "[n]piperelay.exe -ei -s //./pipe/openssh-ssh-agent"; echo $?)
+if [[ $ALREADY_RUNNING != "0" ]]; then
+    if [[ -S $SSH_AUTH_SOCK ]]; then
+        # not expecting the socket to exist as the forwarding command isn't running (http://www.tldp.org/LDP/abs/html/fto.html)
+        echo "removing previous socket..."
+        rm $SSH_AUTH_SOCK
+    fi
+    echo "Starting SSH-Agent relay..."
+    # setsid to force new session to keep running
+    # set socat to listen on $SSH_AUTH_SOCK and forward to npiperelay which then forwards to openssh-ssh-agent on windows
+    (setsid socat UNIX-LISTEN:$SSH_AUTH_SOCK,fork EXEC:"npiperelay.exe -ei -s //./pipe/openssh-ssh-agent",nofork &) >/dev/null 2>&1
+fi
+
 if which onedrive > /dev/null
 then
     # onedrive --synchronize --single-directory 'emacs' > /dev/null &

--- a/.zsh/.zshrc.mine
+++ b/.zsh/.zshrc.mine
@@ -63,6 +63,9 @@ then
     if which setxkbmap > /dev/null; then setxkbmap -layout us; fi
 fi
 
+# require 1Password integration
+# source $HOME/.config/op/plugins.sh
+
 # if which docker > /dev/null; then
 #    export ONEDRIVE_DATA_DIR="$HOME/OneDrive - Skirnir Inc"
 #    export ONEDRIVE_GID=$(id -g)


### PR DESCRIPTION
This pull request introduces 1Password integration into the Zsh configuration to enable SSH key management in a WSL2 environment. The changes include setting up aliases for OpenSSH executables, adding a relay mechanism for SSH-Agent, and preparing for potential 1Password plugin integration.

### 1Password Integration:

* [`.zsh/.zaliases`](diffhunk://#diff-c9643d3fd0a9f51067397bca59b65a2227d4dff09e39a2b40787921e44b3560dR83-R86): Added aliases for `ssh` and `ssh-add` to use the Windows OpenSSH executables.
* [`.zsh/.zshrc`](diffhunk://#diff-b029ac728a5e2449166d53018e7fa57456d71efe0889fed3fa8d44d1781ff9f3R77-R92): Implemented a relay mechanism using `socat` and `npiperelay.exe` to forward the SSH-Agent socket from Windows to WSL2. This includes checking if the relay is already running and cleaning up any existing socket before starting the relay.

### Preparation for 1Password Plugin:

* [`.zsh/.zshrc.mine`](diffhunk://#diff-a25aee57d2ba174b450c04f23960538b2f4d6a20b9f39e826210e12198dbb5c8R66-R68): Added a commented-out line to source a 1Password plugin script, indicating future plans for deeper integration.